### PR TITLE
feat: add flavor text and get specie info

### DIFF
--- a/i18n/en/starry_dex.ftl
+++ b/i18n/en/starry_dex.ftl
@@ -50,6 +50,7 @@ show-encounter-details = Show Encounter Details
 no-encounter-info = No encounter info...
 link-more-info = More Info
 pokemon-abilities = Pokémon Abilities
+no-flavor-text = No flavor text available...
 
 <#-- Filters Page -->
 filters-page = Filters

--- a/i18n/es/starry_dex.ftl
+++ b/i18n/es/starry_dex.ftl
@@ -48,6 +48,7 @@ show-encounter-details = Detalles de encuentro
 no-encounter-info = No hay detalles de encuentro...
 link-more-info = Más Información
 pokemon-abilities = Habilidades
+no-flavor-text = Sin descripción...
 
 <#-- Filters Page -->
 filters-page = Filtros

--- a/src/app.rs
+++ b/src/app.rs
@@ -1011,6 +1011,16 @@ impl StarryDex {
                 .padding(10.)
                 .class(theme::Container::Card);
 
+                let pokemon_flavor_text = if let Some(specie_info) = &starry_pokemon.specie {
+                    widget::text::body(specie_info.flavor_text.clone().unwrap_or_default())
+                        .align_x(Alignment::Center)
+                        .width(Length::Fill)
+                } else {
+                    widget::text::body(fl!("no-flavor-text"))
+                        .align_x(Alignment::Center)
+                        .width(Length::Fill)
+                };
+
                 let pokemon_first_row = widget::Row::new()
                     .push(pokemon_weight)
                     .push(pokemon_height)
@@ -1021,6 +1031,7 @@ impl StarryDex {
                     .push(page_title)
                     .push(pokemon_image)
                     .push(pokemon_types)
+                    .push(pokemon_flavor_text)
                     .push(pokemon_first_row)
                     .push(pokemon_abilities)
                     .push(pokemon_stats)

--- a/src/entities.rs
+++ b/src/entities.rs
@@ -9,6 +9,7 @@ use rkyv::{Archive, Deserialize, Serialize};
 #[rkyv(derive(Debug))]
 pub struct StarryPokemon {
     pub pokemon: StarryPokemonData,
+    pub specie: Option<StarryPokemonSpecie>,
     pub sprite_path: Option<String>,
     pub encounter_info: Option<Vec<StarryPokemonEncounterInfo>>,
 }
@@ -98,4 +99,13 @@ impl Debug for PokemonInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("PokemonInfo").field("id", &self.id).finish()
     }
+}
+
+/// Pokémon specie
+#[derive(Archive, CheckBytes, Serialize, Deserialize)]
+#[rkyv(derive(Debug))]
+pub struct StarryPokemonSpecie {
+    pub evolution_chain_url: Option<String>,
+    pub flavor_text: Option<String>,
+    pub generation: String,
 }


### PR DESCRIPTION
This is still a draft and will not get implemented for now, I'm keeping this open to implement it in the future whenever the text alignment works as in iced master so that this does not happen.

![image](https://github.com/user-attachments/assets/0822a25b-3dd7-40e8-aa22-6056fcf8978b)
 
master: 
![image](https://github.com/user-attachments/assets/97b089e3-4570-4193-a406-235d2d6b5a0e)

When the text moves to a new line it gets properly centered. (don't know which commit this is from but the screenshot is from 10/03/2025)